### PR TITLE
Added sending of snapshot on mqtt trigger

### DIFF
--- a/src/protect-camera.ts
+++ b/src/protect-camera.ts
@@ -675,7 +675,7 @@ export class ProtectCamera extends ProtectAccessory {
 
       this.stream?.getSnapshot().then(snapshot => {
         if (snapshot) {
-          this.nvr.mqtt?.publish(this.accessory, "snapshot", snapshot.toString());
+          this.nvr.mqtt?.publish(this.accessory, "snapshot", "data:image/jpeg;base64," + snapshot.toString("base64"));
           this.log.info("%s: Snapshot published via MQTT.", this.name());
         }
       });

--- a/src/protect-camera.ts
+++ b/src/protect-camera.ts
@@ -8,11 +8,11 @@ import {
   CharacteristicSetCallback,
   CharacteristicValue
 } from "homebridge";
-import { ProtectCameraChannelConfig, ProtectCameraConfig, ProtectNvrBootstrap } from "./protect-types";
 import { ProtectAccessory } from "./protect-accessory";
 import { ProtectApi } from "./protect-api";
 import { ProtectNvr } from "./protect-nvr";
 import { ProtectStreamingDelegate } from "./protect-stream";
+import { ProtectCameraChannelConfig, ProtectCameraConfig, ProtectNvrBootstrap } from "./protect-types";
 
 // Manage our switch types.
 export const PROTECT_SWITCH_DOORBELL_TRIGGER = "DoorbellTrigger";
@@ -673,7 +673,12 @@ export class ProtectCamera extends ProtectAccessory {
         return;
       }
 
-      void this.stream?.getSnapshot();
+      this.stream?.getSnapshot().then(snapshot => {
+        if (snapshot) {
+          this.nvr.mqtt?.publish(this.accessory, "snapshot", snapshot.toString());
+          this.log.info("%s: Snapshot published via MQTT.", this.name());
+        }
+      });
       this.log.info("%s: Snapshot triggered via MQTT.", this.name());
     });
 


### PR DESCRIPTION
I was wondering why on the `snapshot/trigger` MQTT message no snapshot was send, even the correct log message shown in Homebridge log (`Snapshot triggered via MQTT.`), so I was looking around in the code to see what could possibly go wrong and it seems, that the snapshot never was send upon MQTT trigger in the code.

This is why I propose to add the changes in this PR to actually send the snaphot as base64 encoded data uri. I was not sure if it is okay to send the snapshot also to Homekit at this point, since it hasn't requested it, so I skipped that.
Hopefully this reflects the intended behaviour!

I tested it in my local setup with the following configuration:
* installed via Docker
* homebride version: 1.3.3
* Node.js Version: 14.16.0
* NPM version: 6.14.11

The testing instance has no other plugins installed (only the preinstalled `Homebridge UI` and `Homebridge Dummy`) and has no other configuration than the one for your plugin.