### PR TITLE
Add configuration option to specify ffmpeg encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Audio on cameras is tricky in the HomeKit world to begin with, and when you thro
 }
 ```
 
+To use hardware accelerated transcoding, enable feature option `Enable.Video.Transcode` and set an FFmpeg encoder for the `ffmpegEncoder` configuration. E.g.: use `h264_omx` for Raspberry Pi 4 hardware acceleration.
+
 ### Things To Be Aware Of
 - **Make sure you are running on the latest production / stable firmwares for both your controller platform (UCKgen2+, UDM-Pro, UNVR, etc.) as well as the latest production / stable UniFi Protect controller firmware.**
 - **No beta versions of iOS, iPadOS, macOS, tvOS, or watchOS are supported. You are on your own if you choose to install / run beta firmwares - don't expect support or sympathy if you run into issues.**

--- a/config.schema.json
+++ b/config.schema.json
@@ -148,6 +148,13 @@
         "title": "Verbose FFmpeg Logging",
         "required": false,
         "description": "Enable additional logging for FFmpeg. This will create a lot of logging when video streams are running. Default: false."
+      },
+
+      "ffmpegEncoder": {
+        "type": "string",
+        "title": "FFmpeg Encoder for transcoding",
+        "required": false,
+        "description": "FFmpeg Encoder to use for transcoding when optional video transcoding is enabled. Use h264_omx for Raspberry Pi4 hardware acceleration. Default: libx264."
       }
     }
   },
@@ -261,7 +268,8 @@
           "items": [
             "videoProcessor",
             "motionDuration",
-            "verboseFfmpeg"
+            "verboseFfmpeg",
+            "ffmpegEncoder"
           ]
         }
       ]

--- a/docs/AdvancedOptions.md
+++ b/docs/AdvancedOptions.md
@@ -66,6 +66,7 @@ This step is not required. The defaults should work well for almost everyone, bu
 | doorbellMessages       | Configure [doorbell messages](https://github.com/hjdhjd/homebridge-unifi-protect/blob/master/docs/Doorbell.md) for your UniFi Protect controller. | [] | No |
 | videoProcessor         | Specify path of ffmpeg or avconv.                       | "ffmpeg"                                                                              | No       |
 | ffmpegOptions          | Additional parameters to pass ffmpeg to render video.   |                                                                                       | No       |
+| ffmpegEncoder          | Specify FFmpeg encoder for use with transcoding. | libx264 | No       |
 | motionDuration         | Duration of motion events. Setting this too low will potentially cause a lot of notification spam. | 10                                         | No       |
 | refreshInterval        | Interval, in seconds, to check UniFi Protect for new or removed devices. | 10                                                                   | No       |
 | options                | Configure plugin [feature options](https://github.com/hjdhjd/homebridge-unifi-protect/blob/master/docs/FeatureOptions.md).   | []               | No       |

--- a/src/protect-platform.ts
+++ b/src/protect-platform.ts
@@ -45,7 +45,8 @@ export class ProtectPlatform implements DynamicPlatformPlugin {
       motionDuration: config.motionDuration as number ?? PROTECT_MOTION_DURATION,
       options: config.options as string[],
       verboseFfmpeg: config.verboseFfmpeg === true,
-      videoProcessor: config.videoProcessor as string
+      videoProcessor: config.videoProcessor as string,
+      ffmpegEncoder: config.ffmpegEncoder as string
     };
 
     // We need a UniFi Protect controller configured to do anything.

--- a/src/protect-stream.ts
+++ b/src/protect-stream.ts
@@ -311,10 +311,10 @@ export class ProtectStreamingDelegate implements CameraStreamingDelegate {
 
       // Configure our video parameters for transcoding:
       //
-      // -vcodec libx264    copy the stream withour reencoding it.
+      // -vcodec libx264    copy the stream without reencoding it.
       // -pix_fmt yuvj420p  use the yuvj420p pixel format, which is what Protect uses.
       // -profile:v high    use the H.264 high profile when encoding, which provides for better stream quality and size efficiency.
-      // -preset veryfast   use the veryfast encoding preset in libx264, which provides a good balance of encoding speed and quality.
+      // -preset veryfast   use the veryfast encoding preset, which provides a good balance of encoding speed and quality.
       // -bf 0              disable B-frames when encoding to increase compatibility against occasionally finicky HomeKit clients.
       // -b:v bitrate       the average bitrate to use for this stream. This is specified by HomeKit.
       // -bufsize size      this is the decoder buffer size, which drives the variability / quality of the output bitrate.
@@ -322,8 +322,9 @@ export class ProtectStreamingDelegate implements CameraStreamingDelegate {
       //                    create a constant bitrate.
       // -filter:v fps=fps= use the fps filter to get to the frame rate requested by HomeKit. This has better performance characteristics
       //                    for Protect rather than using "-r".
+      ffmpegArgs.push("-vcodec", this.platform.config.ffmpegEncoder ?? "libx264");
+
       ffmpegArgs.push(
-        "-vcodec", "libx264",
         "-pix_fmt", "yuvj420p",
         "-profile:v", "high",
         "-preset", "veryfast",

--- a/src/protect-types.ts
+++ b/src/protect-types.ts
@@ -461,7 +461,8 @@ export interface ProtectOptions {
   motionDuration: number,
   options: string[],
   verboseFfmpeg: boolean,
-  videoProcessor: string
+  videoProcessor: string,
+  ffmpegEncoder: string,
 }
 
 // NVR configuration options.


### PR DESCRIPTION
This change adds the ability to specify an encoder option for FFmpeg's `-vcodec` command line option. It keeps the default behavior of using `libx264` when using transcoding with the `Enable.Video.Transcode` feature, but allows for the specification of another value to allow the use of hardware accelerated encoding plugins. This can greatly improve latency of transcoding on platforms such as a Raspberry Pi 4.

The change was tested with a Pi4 and using the `h264_omx` encoder.