### PR TITLE
Add option to disable status light toggle

### DIFF
--- a/docs/FeatureOptions.md
+++ b/docs/FeatureOptions.md
@@ -85,6 +85,7 @@ In this example:
 Feature options provide a rich mechanism for tailoring your `homebridge-unifi-protect` experience. The reference below is divided into functional category groups:
 
   * [Audio](#audio): enable, disable, or enable audio filters.
+  * [Camera](#camera): enable or disable specific camera features.
   * [Device](#device): enable or disable specific cameras or Protect controllers.
   * [Doorbell](#doorbell): enable, disable, or customize doorbell features and related automation options.
   * [Logging](#logging): enable or disable logging of motion and doorbell ring events.
@@ -112,6 +113,15 @@ Please review the [audio options documentation](https://github.com/hjdhjd/homebr
 |                                               |
 | `Enable.Audio.TwoWay`                          | Enable two-way audio support using the Home app for supported cameras and doorbells. *(Default)*<BR>**Note that acoustic echo cancellation (AEC) is not currently available and you *will* hear an echo when using the Home app, however those standing at the doorbell (or camera) will hear things correctly.**</BR>
 | `Disable.Audio.TwoWay`                         | Disable two-way audio support.
+
+#### <A NAME="camera"></A>Camera Feature Options
+
+These feature options allow you to configure whether the status light is controlled from Homekit or Unifi Protect (For more info see [Camera Properties Exposed In HomeKit Secure video](https://github.com/hjdhjd/homebridge-unifi-protect/blob/main/docs/HomeKitSecureVideo.md#camera-properties-exposed-in-homekit-secure-video)).
+
+| Option                                        | Description
+|-----------------------------------------------|----------------------------------
+| <CODE>Enable.Camera.StatusLight</CODE>        | Show the camera status light toggle in Homekit *(Default)*.
+| <CODE>Disable.Camera.StatusLight</CODE>       | Hide the camera status light toggle in Homekit. Control it from Unifi Protect instead.
 
 #### <A NAME="device"></A>Device Feature Options
 These feature options allow you to control which Protect devices or controllers are enabled or disabled within HomeKit.

--- a/src/protect-camera.ts
+++ b/src/protect-camera.ts
@@ -414,8 +414,8 @@ export class ProtectCamera extends ProtectAccessory {
     // Grab our device context.
     const device = this.accessory.context.device as ProtectCameraConfig;
 
-    // Turn the status light on or off.
-    if(device.featureFlags.hasLedStatus) {
+    // Turn the status light on or off unless the feature is unavailable or the user has disabled it.
+    if(device.featureFlags.hasLedStatus && this.nvr?.optionEnabled(device, "Camera.StatusLight", true)) {
 
       service?.getCharacteristic(this.hap.Characteristic.CameraOperatingModeIndicator)
         ?.onGet(() => {
@@ -443,6 +443,11 @@ export class ProtectCamera extends ProtectAccessory {
 
       // Initialize the status light state.
       service?.updateCharacteristic(this.hap.Characteristic.CameraOperatingModeIndicator, device.ledSettings.isEnabled === true);
+    } else {
+      const cameraOperatingModeCharacteristic = service?.getCharacteristic(this.hap.Characteristic.CameraOperatingModeIndicator);
+
+      // Remove the characteristic if it was previously added.
+      cameraOperatingModeCharacteristic && service?.removeCharacteristic(cameraOperatingModeCharacteristic);
     }
 
     return true;
@@ -949,9 +954,8 @@ export class ProtectCamera extends ProtectAccessory {
     // Find the service, if it exists.
     const service = this.accessory.getService(this.hap.Service.CameraOperatingMode);
 
-    // Check to see if this device has a status light.
-    if(device.featureFlags.hasLedStatus) {
-
+    // Check to see if this device has a status light and whether it's not disabled by the user.
+    if(device.featureFlags.hasLedStatus && this.nvr?.optionEnabled(device, "Camera.StatusLight", true)) {
       service?.updateCharacteristic(this.hap.Characteristic.CameraOperatingModeIndicator, device.ledSettings.isEnabled === true);
     }
 


### PR DESCRIPTION
This PR adds an option to disable the status light toggle in Homekit. It's very frustrating there's a bug in Homekit that randomly enables the status lights, even when the setting is turned off in both Homekit and Protect.

Let me know what you think and if I need to make any adjustments. I think the new `Camera` scope was the right place to put it as it only applies to cameras. I only implemented global configuration since it's a Homekit bug.

Fixes https://github.com/hjdhjd/homebridge-unifi-protect/issues/789, https://github.com/hjdhjd/homebridge-unifi-protect/issues/780 and https://github.com/hjdhjd/homebridge-unifi-protect/issues/753