### PR TITLE
Add debug logging for skipped events for devices with active timers.

### DIFF
--- a/src/protect-nvr-events.ts
+++ b/src/protect-nvr-events.ts
@@ -527,6 +527,7 @@ export class ProtectNvrEvents {
     // If we already have a motion event inflight, allow it to complete so we don't spam users.
     if(this.eventTimers[device.mac]) {
 
+      this.debug("%s: Skipping motion event due to another motion event already being inflight for this device.", this.nvrApi.getFullName(device));
       return;
     }
 


### PR DESCRIPTION
Other skip reasons are already logged. Slightly related to #834, helped me to figure out the root cause.