### PR TITLE
Don't skip smart detections due to earlier motion event (or the other way around).

### DIFF
--- a/src/protect-nvr-events.ts
+++ b/src/protect-nvr-events.ts
@@ -525,8 +525,16 @@ export class ProtectNvrEvents {
     this.lastMotion[device.mac] = lastMotion;
 
     // If we already have a motion event inflight, allow it to complete so we don't spam users.
-    if(this.eventTimers[device.mac]) {
+    if(this.eventTimers[device.mac] && !detectedObjects.length) {
 
+      this.debug("%s: Skipping motion event due to another event already being inflight for this device.", this.nvrApi.getFullName(device));
+      return;
+    }
+
+    // If we already have a smart detection event inflight, allow it to complete so we don't spam users.
+    if(this.eventTimers[device.mac + ".Motion.SmartDetect.ObjectSensors"] && detectedObjects.length) {
+
+      this.debug("%s: Skipping smart detection event due to another event already being inflight for this device.", this.nvrApi.getFullName(device));
       return;
     }
 


### PR DESCRIPTION
This is how I've solved #834. 

If someone is currently using both the motion and smart motion HomeKit outputs, this can lead to both triggering for the same thing. Since the smart motion event currently never triggers with an active motion event I don't think this will impact anyone?