### PR TITLE
Add toggle to pass Low-Power flag to ffmpeg encoder. Useful with QSV encoder on Gen9 and higher CPUs

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -148,7 +148,7 @@
         "type": "boolean",
         "title": "QSV Low Power Mode. Only useful when video encoder is h264_qsv.",
         "required": false,
-        "description": "Enable Low Power mode for the QSV encoder. Default: false."
+        "description": "Enable Low Power mode for the QSV encoder. Only supported on Gen9 CPUs and higher. Default: false."
       },
       
       "ringDuration": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -142,7 +142,15 @@
           "placeholder": "e.g. Disable.Video.Transcode"
         }
       },
+      
+      "qsvLowPower": {
 
+        "type": "boolean",
+        "title": "QSV Low Power Mode. Only useful when video encoder is h264_qsv.",
+        "required": false,
+        "description": "Enable Low Power mode for the QSV encoder. Default: false."
+      },
+      
       "ringDuration": {
 
         "type": "integer",
@@ -296,6 +304,7 @@
             "videoProcessor",
             "videoEncoder",
             "verboseFfmpeg",
+            "qsvLowPower",
             "ringDuration"
           ]
         }

--- a/src/protect-ffmpeg-record.ts
+++ b/src/protect-ffmpeg-record.ts
@@ -110,6 +110,12 @@ export class FfmpegRecordingProcess extends FfmpegProcess {
       );
     }
 
+    // Configure QSV Low Power mode
+    //
+    if (this.protectCamera.platform.config.qsvLowPower) {
+        this.commandLineArgs.push("-low_power", "1");
+    }
+
     // Configure our video parameters for outputting our final stream:
     //
     // -f mp4  Tell ffmpeg that it should create an MP4-encoded output stream.

--- a/src/protect-options.ts
+++ b/src/protect-options.ts
@@ -14,6 +14,7 @@ export interface ProtectOptions {
   debugAll: boolean,
   ffmpegOptions: string[],
   options: string[],
+  qsvLowPower: boolean;
   ringDuration: number,
   verboseFfmpeg: boolean,
   videoEncoder: string,

--- a/src/protect-platform.ts
+++ b/src/protect-platform.ts
@@ -62,6 +62,7 @@ export class ProtectPlatform implements DynamicPlatformPlugin {
       debugAll: config.debug as boolean === true,
       ffmpegOptions: config.ffmpegOptions as string[] ?? PROTECT_FFMPEG_OPTIONS,
       options: config.options as string[],
+      qsvLowPower: config.qsvLowPower === true,
       ringDuration: config.ringDuration as number ?? PROTECT_RING_DURATION,
       verboseFfmpeg: config.verboseFfmpeg === true,
       videoEncoder: config.videoEncoder as string,


### PR DESCRIPTION
Initial implementation for passing "-low_power 1" to the ffmpeg encoder.