### PR TITLE
Added ability to 'ring' the Doorbell via MQTT on topic doorbell/trigger

### DIFF
--- a/docs/MQTT.md
+++ b/docs/MQTT.md
@@ -26,7 +26,7 @@ I've provided MQTT support for those that are interested - I'm genuinely curious
 
   * Camera-specific RTSP information.
   * Doorbell message events. See [doorbell message events](#doorbell-messages) for additional details.
-  * Doorbell ring events.
+  * Doorbell ring events. Including triggering via MQTT.
   * Liveview-related events, including the security system accessory and security alarm.
   * Motion events.
   * Snapshot events, including publishing the actual images over MQTT.
@@ -106,6 +106,7 @@ The topics that `homebridge-unifi-protect` subscribes to are:
 | `securitysystem/set`    | One of `AlarmOff`, `AlarmOn`, `Away`, `Home`, `Night`, `Off`. This will set the respective state on the security system accessory.
 |                         |
 | `snapshot/trigger`      | `true` will trigger the camera or doorbell to generate a snapshot.
+| `doorbell/trigger`      | `true` will trigger the camera (if set as doorbell) or doorbell to generate a ring event.
 | `temperature/get`       | `true` will trigger a publish event of the temperature, in Celsius, for a UniFi Protect sensor.
 
 Some messages, such as those for the liveviews and securitysystem topics, are controller-specific. To use these topics, make sure you use the controller MAC address when you create your topic strings.

--- a/src/protect-camera.ts
+++ b/src/protect-camera.ts
@@ -1085,6 +1085,20 @@ export class ProtectCamera extends ProtectDevice {
       this.log.info("Snapshot triggered via MQTT.");
     });
 
+    // Trigger doorbell when requested.
+    this.nvr.mqtt?.subscribe(this.accessory, "doorbell/trigger", (message: Buffer) => {
+
+      const value = message.toString();
+
+      // When we get the right message, we trigger the doorbell request.
+      if(value?.toLowerCase() !== "true") {
+
+        return;
+      }
+      this.nvr.events.doorbellEventHandler(this, Date.now());
+      this.log.info("Doorbell ring event triggered via MQTT.");
+    });
+
     return true;
   }
 


### PR DESCRIPTION
Hi!

Found this package to work really well, but needed the ability to trigger a 'ring' in homekit for our dumb doorbell.

Specific need was for where we have a camera but no Unifi doorbell, plus no ability to cable up power to fit one.

This works well in testing, and seems to meet the below 'expired-out' tickets as well:

https://github.com/hjdhjd/homebridge-unifi-protect/issues/593 
https://github.com/hjdhjd/homebridge-unifi-protect/issues/131

Let me know what you think!

Thanks,

Glyn